### PR TITLE
Add dummy Zustand store

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "react-dom": "^19.1.0",
         "react-router-dom": "^6.30.1",
         "react-scripts": "5.0.1",
-        "web-vitals": "^2.1.4"
+        "web-vitals": "^2.1.4",
+        "zustand": "^5.0.5"
       },
       "devDependencies": {
         "autoprefixer": "^10.4.21",
@@ -17603,6 +17604,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.5.tgz",
+      "integrity": "sha512-mILtRfKW9xM47hqxGIxCv12gXusoY/xTSHBYApXozR0HmQv299whhBeeAcRy+KrPPybzosvJBCOmVjq6x12fCg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "react-dom": "^19.1.0",
     "react-router-dom": "^6.30.1",
     "react-scripts": "5.0.1",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "zustand": "^5.0.5"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/store/useDummy.js
+++ b/src/store/useDummy.js
@@ -1,0 +1,65 @@
+import { create } from 'zustand';
+
+const useDummy = create((set, get) => ({
+  services: [
+    {
+      id: 1,
+      name: 'Quick Clean',
+      avatar: '/avatars/service1.png',
+      location: '123 Main St',
+      ratings: 4.5,
+      specialties: ['Exterior Wash', 'Interior Cleaning'],
+      availableSlots: [
+        { date: '2025-06-15', times: ['09:00', '11:00'] },
+        { date: '2025-06-16', times: ['10:00', '14:00'] }
+      ]
+    },
+    {
+      id: 2,
+      name: 'Deluxe Detail',
+      avatar: '/avatars/service2.png',
+      location: '456 Pine Rd',
+      ratings: 4.8,
+      specialties: ['Exterior Wash', 'Waxing'],
+      availableSlots: [
+        { date: '2025-06-15', times: ['13:00', '15:00'] }
+      ]
+    }
+  ],
+  products: [
+    { id: 1, name: 'Car Shampoo', code: 'CS001', qty: 10, category: 'Cleaning' },
+    { id: 2, name: 'Microfiber Cloth', code: 'MC002', qty: 25, category: 'Accessories' }
+  ],
+  appointments: [
+    { id: 1, serviceId: 1, customerName: 'John Doe', date: '2025-06-15', time: '09:00', package: 'Basic Wash' }
+  ],
+
+  addService: (service) => set(state => ({ services: [...state.services, service] })),
+  updateService: (id, data) => set(state => ({
+    services: state.services.map(s => s.id === id ? { ...s, ...data } : s)
+  })),
+  deleteService: (id) => set(state => ({
+    services: state.services.filter(s => s.id !== id)
+  })),
+
+  addProduct: (product) => set(state => ({ products: [...state.products, product] })),
+  updateProduct: (id, data) => set(state => ({
+    products: state.products.map(p => p.id === id ? { ...p, ...data } : p)
+  })),
+  deleteProduct: (id) => set(state => ({
+    products: state.products.filter(p => p.id !== id)
+  })),
+  updateStock: (productId, delta) => set(state => ({
+    products: state.products.map(p => p.id === productId ? { ...p, qty: p.qty + delta } : p)
+  })),
+
+  addAppointment: (appointment) => set(state => ({ appointments: [...state.appointments, appointment] })),
+  updateAppointment: (id, data) => set(state => ({
+    appointments: state.appointments.map(a => a.id === id ? { ...a, ...data } : a)
+  })),
+  deleteAppointment: (id) => set(state => ({
+    appointments: state.appointments.filter(a => a.id !== id)
+  }))
+}));
+
+export default useDummy;


### PR DESCRIPTION
## Summary
- install `zustand`
- add a dummy store with services, products and appointments

## Testing
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68497cd50814832996bc51e5234cb5b1