### PR TITLE
Add customer dashboard and booking pages

### DIFF
--- a/src/components/BookingModal.jsx
+++ b/src/components/BookingModal.jsx
@@ -1,0 +1,73 @@
+import React, { useState } from 'react';
+import useDummy from '../store/useDummy';
+
+const BookingModal = ({ service, open, onClose }) => {
+  const addAppointment = useDummy((s) => s.addAppointment);
+  const [date, setDate] = useState('');
+  const [time, setTime] = useState('');
+
+  if (!open) return null;
+
+  const slots = service.availableSlots || [];
+  const timesForDate =
+    slots.find((s) => s.date === date)?.times || [];
+
+  const handleBook = () => {
+    if (date && time) {
+      addAppointment({
+        id: Date.now(),
+        serviceId: service.id,
+        customerName: 'Guest',
+        date,
+        time,
+      });
+      onClose();
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-20">
+      <div className="bg-white p-4 rounded w-80 space-y-4">
+        <h2 className="text-lg font-semibold">Book {service.name}</h2>
+        <div>
+          <label className="block text-sm">Date</label>
+          <input
+            type="date"
+            className="border rounded p-1 w-full"
+            value={date}
+            onChange={(e) => {
+              setDate(e.target.value);
+              setTime('');
+            }}
+          />
+        </div>
+        {date && (
+          <div>
+            <label className="block text-sm mb-1">Time</label>
+            <div className="space-y-1">
+              {timesForDate.map((t) => (
+                <label key={t} className="flex items-center space-x-2">
+                  <input
+                    type="radio"
+                    name="time"
+                    value={t}
+                    checked={time === t}
+                    onChange={() => setTime(t)}
+                  />
+                  <span>{t}</span>
+                </label>
+              ))}
+              {!timesForDate.length && <p className="text-sm text-gray-500">No times</p>}
+            </div>
+          </div>
+        )}
+        <div className="flex justify-end space-x-2">
+          <button onClick={onClose} className="px-3 py-1 rounded bg-gray-200">Cancel</button>
+          <button onClick={handleBook} className="px-3 py-1 rounded bg-primary text-white">Book</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default BookingModal;

--- a/src/components/CancelModal.jsx
+++ b/src/components/CancelModal.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import useDummy from '../store/useDummy';
+
+const CancelModal = ({ appointmentId, open, onClose }) => {
+  const deleteAppointment = useDummy((s) => s.deleteAppointment);
+
+  if (!open) return null;
+
+  const handleCancel = () => {
+    deleteAppointment(appointmentId);
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-20">
+      <div className="bg-white p-4 rounded w-72 space-y-4">
+        <h2 className="text-lg font-semibold">Cancel appointment?</h2>
+        <div className="flex justify-end space-x-2">
+          <button onClick={onClose} className="px-3 py-1 rounded bg-gray-200">No</button>
+          <button onClick={handleCancel} className="px-3 py-1 rounded bg-primary text-white">Yes</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CancelModal;

--- a/src/components/RescheduleModal.jsx
+++ b/src/components/RescheduleModal.jsx
@@ -1,0 +1,66 @@
+import React, { useState } from 'react';
+import useDummy from '../store/useDummy';
+
+const RescheduleModal = ({ appointment, service, open, onClose }) => {
+  const updateAppointment = useDummy((s) => s.updateAppointment);
+  const [date, setDate] = useState(appointment.date);
+  const [time, setTime] = useState(appointment.time);
+
+  if (!open) return null;
+
+  const timesForDate =
+    service.availableSlots.find((s) => s.date === date)?.times || [];
+
+  const handleSave = () => {
+    if (date && time) {
+      updateAppointment(appointment.id, { date, time });
+      onClose();
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-20">
+      <div className="bg-white p-4 rounded w-80 space-y-4">
+        <h2 className="text-lg font-semibold">Reschedule</h2>
+        <div>
+          <label className="block text-sm">Date</label>
+          <input
+            type="date"
+            className="border rounded p-1 w-full"
+            value={date}
+            onChange={(e) => {
+              setDate(e.target.value);
+              setTime('');
+            }}
+          />
+        </div>
+        {date && (
+          <div>
+            <label className="block text-sm mb-1">Time</label>
+            <div className="space-y-1">
+              {timesForDate.map((t) => (
+                <label key={t} className="flex items-center space-x-2">
+                  <input
+                    type="radio"
+                    name="time"
+                    value={t}
+                    checked={time === t}
+                    onChange={() => setTime(t)}
+                  />
+                  <span>{t}</span>
+                </label>
+              ))}
+              {!timesForDate.length && <p className="text-sm text-gray-500">No times</p>}
+            </div>
+          </div>
+        )}
+        <div className="flex justify-end space-x-2">
+          <button onClick={onClose} className="px-3 py-1 rounded bg-gray-200">Cancel</button>
+          <button onClick={handleSave} className="px-3 py-1 rounded bg-primary text-white">Save</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default RescheduleModal;

--- a/src/components/ServiceCard.jsx
+++ b/src/components/ServiceCard.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+const ServiceCard = ({ service, onClick }) => (
+  <div
+    className="rounded shadow hover:shadow-lg p-4 cursor-pointer bg-white"
+    onClick={() => onClick && onClick(service)}
+  >
+    {service.avatar && (
+      <img
+        src={service.avatar}
+        alt={service.name}
+        className="w-full h-32 object-cover rounded mb-2"
+      />
+    )}
+    <h3 className="font-semibold text-lg">{service.name}</h3>
+    <p className="text-sm text-gray-500">{service.location}</p>
+    <p className="text-sm">Rating: {service.ratings}</p>
+  </div>
+);
+
+export default ServiceCard;

--- a/src/layouts/CustomerLayout.jsx
+++ b/src/layouts/CustomerLayout.jsx
@@ -1,7 +1,35 @@
-import React from 'react';
+import React, { lazy, Suspense } from 'react';
+import { Routes, Route, Link } from 'react-router-dom';
+import TopBar from '../components/TopBar';
 
-const CustomerLayout = () => {
-  return <div />;
-};
+const Dashboard = lazy(() => import('../pages/customer/Dashboard'));
+const ServiceList = lazy(() => import('../pages/customer/ServiceList'));
+const Appointments = lazy(() => import('../pages/customer/Appointments'));
+
+const CustomerLayout = () => (
+  <div className="min-h-screen flex flex-col">
+    <TopBar />
+    <nav className="bg-gray-100 p-2 space-x-4">
+      <Link to="" className="hover:underline">
+        Dashboard
+      </Link>
+      <Link to="services" className="hover:underline">
+        Services
+      </Link>
+      <Link to="appointments" className="hover:underline">
+        Appointments
+      </Link>
+    </nav>
+    <div className="p-4 flex-1">
+      <Suspense fallback={null}>
+        <Routes>
+          <Route index element={<Dashboard />} />
+          <Route path="services" element={<ServiceList />} />
+          <Route path="appointments" element={<Appointments />} />
+        </Routes>
+      </Suspense>
+    </div>
+  </div>
+);
 
 export default CustomerLayout;

--- a/src/pages/customer/Appointments.jsx
+++ b/src/pages/customer/Appointments.jsx
@@ -1,0 +1,82 @@
+import React, { useState } from 'react';
+import useDummy from '../../store/useDummy';
+import RescheduleModal from '../../components/RescheduleModal';
+import CancelModal from '../../components/CancelModal';
+
+const Appointments = () => {
+  const services = useDummy((s) => s.services);
+  const appointments = useDummy((s) => s.appointments);
+  const [tab, setTab] = useState('upcoming');
+  const [rescheduleFor, setRescheduleFor] = useState(null);
+  const [cancelFor, setCancelFor] = useState(null);
+
+  const now = new Date();
+  const upcoming = appointments.filter((a) => new Date(`${a.date}T${a.time}`) >= now);
+  const past = appointments.filter((a) => new Date(`${a.date}T${a.time}`) < now);
+
+  const list = tab === 'upcoming' ? upcoming : past;
+
+  const getService = (id) => services.find((s) => s.id === id) || {};
+
+  return (
+    <div>
+      <div className="mb-4 space-x-2">
+        <button
+          className={`px-3 py-1 rounded ${tab === 'upcoming' ? 'bg-primary text-white' : 'bg-gray-200'}`}
+          onClick={() => setTab('upcoming')}
+        >
+          Upcoming
+        </button>
+        <button
+          className={`px-3 py-1 rounded ${tab === 'past' ? 'bg-primary text-white' : 'bg-gray-200'}`}
+          onClick={() => setTab('past')}
+        >
+          Past
+        </button>
+      </div>
+      <div className="space-y-2">
+        {list.map((a) => {
+          const service = getService(a.serviceId);
+          return (
+            <div key={a.id} className="border p-4 rounded bg-white space-y-1">
+              <div className="font-semibold">{service.name}</div>
+              <div className="text-sm text-gray-600">
+                {a.date} at {a.time}
+              </div>
+              {tab === 'upcoming' && (
+                <div className="space-x-2 mt-2">
+                  <button
+                    className="px-2 py-1 text-sm rounded bg-gray-200"
+                    onClick={() => setRescheduleFor({ appt: a, service })}
+                  >
+                    Reschedule
+                  </button>
+                  <button
+                    className="px-2 py-1 text-sm rounded bg-red-500 text-white"
+                    onClick={() => setCancelFor(a.id)}
+                  >
+                    Cancel
+                  </button>
+                </div>
+              )}
+            </div>
+          );
+        })}
+        {!list.length && <p>No appointments.</p>}
+      </div>
+      {rescheduleFor && (
+        <RescheduleModal
+          appointment={rescheduleFor.appt}
+          service={rescheduleFor.service}
+          open={!!rescheduleFor}
+          onClose={() => setRescheduleFor(null)}
+        />
+      )}
+      {cancelFor && (
+        <CancelModal appointmentId={cancelFor} open={!!cancelFor} onClose={() => setCancelFor(null)} />
+      )}
+    </div>
+  );
+};
+
+export default Appointments;

--- a/src/pages/customer/Dashboard.jsx
+++ b/src/pages/customer/Dashboard.jsx
@@ -1,0 +1,39 @@
+import React, { useState } from 'react';
+import useDummy from '../../store/useDummy';
+import ServiceCard from '../../components/ServiceCard';
+
+const Dashboard = () => {
+  const services = useDummy((s) => s.services);
+  const [query, setQuery] = useState('');
+
+  const filtered = services.filter((s) =>
+    s.specialties.join(' ').toLowerCase().includes(query.toLowerCase())
+  );
+
+  const top = [...filtered]
+    .sort((a, b) => b.ratings - a.ratings)
+    .slice(0, 3);
+
+  return (
+    <div>
+      <div className="bg-primary text-white p-6 rounded mb-4 space-y-2">
+        <h1 className="text-2xl font-bold">Find the perfect wash</h1>
+        <input
+          type="text"
+          placeholder="Search by specialty"
+          className="w-full p-2 rounded text-black"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+      </div>
+      <div className="grid md:grid-cols-3 gap-4">
+        {top.map((service) => (
+          <ServiceCard key={service.id} service={service} />
+        ))}
+        {!top.length && <p>No services found.</p>}
+      </div>
+    </div>
+  );
+};
+
+export default Dashboard;

--- a/src/pages/customer/ServiceList.jsx
+++ b/src/pages/customer/ServiceList.jsx
@@ -1,0 +1,24 @@
+import React, { useState } from 'react';
+import useDummy from '../../store/useDummy';
+import ServiceCard from '../../components/ServiceCard';
+import BookingModal from '../../components/BookingModal';
+
+const ServiceList = () => {
+  const services = useDummy((s) => s.services);
+  const [selected, setSelected] = useState(null);
+
+  return (
+    <div>
+      <div className="grid md:grid-cols-3 gap-4">
+        {services.map((service) => (
+          <ServiceCard key={service.id} service={service} onClick={() => setSelected(service)} />
+        ))}
+      </div>
+      {selected && (
+        <BookingModal service={selected} open={!!selected} onClose={() => setSelected(null)} />
+      )}
+    </div>
+  );
+};
+
+export default ServiceList;


### PR DESCRIPTION
## Summary
- implement customer dashboard, services list and appointments pages
- add ServiceCard with booking/reschedule/cancel modals
- wire up customer layout routing

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68498114172083298ab12611855d51e8