### PR TITLE
Add provider dashboard pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^13.5.0",
+        "dayjs": "^1.11.13",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^6.30.1",
@@ -6676,6 +6677,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^13.5.0",
+    "dayjs": "^1.11.13",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^6.30.1",

--- a/src/layouts/ProviderLayout.jsx
+++ b/src/layouts/ProviderLayout.jsx
@@ -1,7 +1,40 @@
-import React from 'react';
+import React, { lazy, Suspense } from 'react';
+import { Routes, Route, Link } from 'react-router-dom';
+import TopBar from '../components/TopBar';
 
-const ProviderLayout = () => {
-  return <div />;
-};
+const Overview = lazy(() => import('../pages/provider/Overview'));
+const Schedule = lazy(() => import('../pages/provider/Schedule'));
+const Services = lazy(() => import('../pages/provider/Services'));
+const Products = lazy(() => import('../pages/provider/Products'));
+
+const ProviderLayout = () => (
+  <div className="min-h-screen flex flex-col">
+    <TopBar />
+    <nav className="bg-gray-100 p-2 space-x-4">
+      <Link to="" className="hover:underline">
+        Overview
+      </Link>
+      <Link to="schedule" className="hover:underline">
+        Schedule
+      </Link>
+      <Link to="services" className="hover:underline">
+        Services
+      </Link>
+      <Link to="products" className="hover:underline">
+        Products
+      </Link>
+    </nav>
+    <div className="p-4 flex-1">
+      <Suspense fallback={null}>
+        <Routes>
+          <Route index element={<Overview />} />
+          <Route path="schedule" element={<Schedule />} />
+          <Route path="services" element={<Services />} />
+          <Route path="products" element={<Products />} />
+        </Routes>
+      </Suspense>
+    </div>
+  </div>
+);
 
 export default ProviderLayout;

--- a/src/pages/provider/Overview.jsx
+++ b/src/pages/provider/Overview.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import dayjs from 'dayjs';
+import useDummy from '../../store/useDummy';
+import Card from '../../components/Card';
+
+const Overview = () => {
+  const appointments = useDummy((s) => s.appointments);
+  const products = useDummy((s) => s.products);
+
+  const total = appointments.length;
+  const today = dayjs().format('YYYY-MM-DD');
+  const todayCount = appointments.filter((a) => a.date === today).length;
+  const lowStock = products.filter((p) => p.qty < 5).length;
+
+  return (
+    <div className="grid md:grid-cols-3 gap-4">
+      <Card>
+        <h3 className="text-lg font-semibold">Total Bookings</h3>
+        <p className="text-2xl">{total}</p>
+      </Card>
+      <Card>
+        <h3 className="text-lg font-semibold">Today's Bookings</h3>
+        <p className="text-2xl">{todayCount}</p>
+      </Card>
+      <Card>
+        <h3 className="text-lg font-semibold">Low Stock Products</h3>
+        <p className="text-2xl">{lowStock}</p>
+      </Card>
+    </div>
+  );
+};
+
+export default Overview;

--- a/src/pages/provider/Products.jsx
+++ b/src/pages/provider/Products.jsx
@@ -1,0 +1,110 @@
+import React, { useState } from 'react';
+import useDummy from '../../store/useDummy';
+import Card from '../../components/Card';
+
+const ProductCard = ({ product }) => {
+  const update = useDummy((s) => s.updateProduct);
+
+  const handleChange = (field, value) => {
+    update(product.id, { [field]: value });
+  };
+
+  return (
+    <Card>
+      <input
+        className="border rounded p-1 mb-1 w-full"
+        value={product.name}
+        onChange={(e) => handleChange('name', e.target.value)}
+      />
+      <input
+        className="border rounded p-1 mb-1 w-full"
+        value={product.code}
+        onChange={(e) => handleChange('code', e.target.value)}
+      />
+      <input
+        type="number"
+        className="border rounded p-1 mb-1 w-full"
+        value={product.qty}
+        onChange={(e) => handleChange('qty', Number(e.target.value))}
+      />
+      <input
+        className="border rounded p-1 w-full"
+        value={product.category}
+        onChange={(e) => handleChange('category', e.target.value)}
+      />
+    </Card>
+  );
+};
+
+const AddProductModal = ({ open, onClose }) => {
+  const add = useDummy((s) => s.addProduct);
+  const [form, setForm] = useState({ name: '', code: '', qty: 0, category: '' });
+
+  if (!open) return null;
+
+  const handleSubmit = () => {
+    add({ id: Date.now(), ...form });
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-20">
+      <div className="bg-white p-4 rounded space-y-2 w-72">
+        <h2 className="text-lg font-semibold">Add Product</h2>
+        <input
+          className="border rounded p-1 w-full"
+          placeholder="Name"
+          value={form.name}
+          onChange={(e) => setForm({ ...form, name: e.target.value })}
+        />
+        <input
+          className="border rounded p-1 w-full"
+          placeholder="Code"
+          value={form.code}
+          onChange={(e) => setForm({ ...form, code: e.target.value })}
+        />
+        <input
+          type="number"
+          className="border rounded p-1 w-full"
+          placeholder="Qty"
+          value={form.qty}
+          onChange={(e) => setForm({ ...form, qty: Number(e.target.value) })}
+        />
+        <select
+          className="border rounded p-1 w-full"
+          value={form.category}
+          onChange={(e) => setForm({ ...form, category: e.target.value })}
+        >
+          <option value="">Category</option>
+          <option value="Cleaning">Cleaning</option>
+          <option value="Accessories">Accessories</option>
+        </select>
+        <div className="flex justify-end space-x-2">
+          <button onClick={onClose} className="px-3 py-1 rounded bg-gray-200">Cancel</button>
+          <button onClick={handleSubmit} className="px-3 py-1 rounded bg-primary text-white">Add</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const Products = () => {
+  const products = useDummy((s) => s.products);
+  const [adding, setAdding] = useState(false);
+
+  return (
+    <div className="space-y-4">
+      <button className="px-3 py-1 rounded bg-primary text-white" onClick={() => setAdding(true)}>
+        Add Product
+      </button>
+      <div className="grid md:grid-cols-3 gap-4">
+        {products.map((p) => (
+          <ProductCard key={p.id} product={p} />
+        ))}
+      </div>
+      <AddProductModal open={adding} onClose={() => setAdding(false)} />
+    </div>
+  );
+};
+
+export default Products;

--- a/src/pages/provider/Schedule.jsx
+++ b/src/pages/provider/Schedule.jsx
@@ -1,0 +1,81 @@
+import React, { useState } from 'react';
+import dayjs from 'dayjs';
+import useDummy from '../../store/useDummy';
+import Card from '../../components/Card';
+
+const Schedule = () => {
+  const slots = useDummy((s) => s.providerSlots);
+  const addSlot = useDummy((s) => s.addSlot);
+  const appointments = useDummy((s) => s.appointments);
+  const markDone = useDummy((s) => s.markAppointmentDone);
+
+  const startHour = 8;
+  const endHour = 18;
+  const increments = (endHour - startHour) * 2; // 30 min increments
+  const times = Array.from({ length: increments }, (_, i) =>
+    dayjs().hour(startHour).minute(i * 30).format('HH:mm')
+  );
+  const [dragStart, setDragStart] = useState(null);
+  const [dragEnd, setDragEnd] = useState(null);
+
+  const handleMouseUp = (i) => {
+    if (dragStart !== null) {
+      const s = Math.min(dragStart, i);
+      const e = Math.max(dragStart, i) + 1;
+      addSlot({
+        id: Date.now(),
+        date: dayjs().format('YYYY-MM-DD'),
+        start: times[s],
+        end: times[e - 1],
+      });
+    }
+    setDragStart(null);
+    setDragEnd(null);
+  };
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <div className="grid grid-cols-1 divide-y">
+          {times.map((t, i) => (
+            <div
+              key={t}
+              className={`p-2 select-none ${
+                dragStart !== null &&
+                i >= Math.min(dragStart, dragEnd ?? dragStart) &&
+                i <= Math.max(dragStart, dragEnd ?? dragStart)
+                  ? 'bg-primary/30'
+                  : ''
+              }`}
+              onMouseDown={() => setDragStart(i)}
+              onMouseEnter={() => dragStart !== null && setDragEnd(i)}
+              onMouseUp={() => handleMouseUp(i)}
+            >
+              {t}
+            </div>
+          ))}
+        </div>
+      </Card>
+      <div className="space-y-2">
+        <h3 className="font-semibold">Appointments</h3>
+        {appointments.map((a) => (
+          <div key={a.id} className="border p-2 rounded bg-white flex justify-between items-center">
+            <span>
+              {a.date} {a.time} - {a.customerName}
+            </span>
+            {a.status !== 'done' && (
+              <button
+                className="px-2 py-1 text-sm rounded bg-primary text-white"
+                onClick={() => markDone(a.id)}
+              >
+                Mark Done
+              </button>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default Schedule;

--- a/src/pages/provider/Services.jsx
+++ b/src/pages/provider/Services.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import useDummy from '../../store/useDummy';
+
+const packagesList = ['Exterior', 'Interior', 'Detailing', 'Paint Protection'];
+
+const Services = () => {
+  const packages = useDummy((s) => s.packages);
+  const toggle = useDummy((s) => s.togglePackage);
+
+  return (
+    <table className="w-full bg-white rounded shadow">
+      <thead>
+        <tr className="text-left">
+          <th className="p-2">Package</th>
+          <th className="p-2">Offered</th>
+        </tr>
+      </thead>
+      <tbody>
+        {packagesList.map((name) => (
+          <tr key={name} className="border-t">
+            <td className="p-2">{name}</td>
+            <td className="p-2">
+              <input
+                type="checkbox"
+                checked={packages[name]}
+                onChange={() => toggle(name)}
+              />
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};
+
+export default Services;

--- a/src/store/useDummy.js
+++ b/src/store/useDummy.js
@@ -33,6 +33,13 @@ const useDummy = create((set, get) => ({
   appointments: [
     { id: 1, serviceId: 1, customerName: 'John Doe', date: '2025-06-15', time: '09:00', package: 'Basic Wash' }
   ],
+  packages: {
+    Exterior: true,
+    Interior: false,
+    Detailing: false,
+    'Paint Protection': false
+  },
+  providerSlots: [],
 
   addService: (service) => set(state => ({ services: [...state.services, service] })),
   updateService: (id, data) => set(state => ({
@@ -59,7 +66,18 @@ const useDummy = create((set, get) => ({
   })),
   deleteAppointment: (id) => set(state => ({
     appointments: state.appointments.filter(a => a.id !== id)
-  }))
+  })),
+
+  markAppointmentDone: (id) => set(state => ({
+    appointments: state.appointments.map(a => a.id === id ? { ...a, status: 'done' } : a)
+  })),
+
+  togglePackage: (name) => set(state => ({
+    packages: { ...state.packages, [name]: !state.packages[name] }
+  })),
+
+  addSlot: (slot) => set(state => ({ providerSlots: [...state.providerSlots, slot] })),
+  deleteSlot: (id) => set(state => ({ providerSlots: state.providerSlots.filter(s => s.id !== id) }))
 }));
 
 export default useDummy;


### PR DESCRIPTION
## Summary
- extend Zustand store for provider features
- implement provider layout with navigation
- add overview, schedule, services, and products pages for providers
- install dayjs dependency for calendar support

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6849860f50cc8329b1c884b82203b54e