### PR TITLE
Enhance ServiceCard with booking CTA

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^13.5.0",
         "dayjs": "^1.11.13",
+        "framer-motion": "^12.17.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^6.30.1",
@@ -8640,6 +8641,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.17.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.17.0.tgz",
+      "integrity": "sha512-2hISKgDk49yCLStwG1wf4Kdy/D6eBw9/eRNaWFIYoI9vMQ/Mqd1Fz+gzVlEtxJmtQ9y4IWnXm19/+UXD3dAYAA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.17.0",
+        "motion-utils": "^12.12.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -11734,6 +11762,21 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.17.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.17.0.tgz",
+      "integrity": "sha512-FA6/c70R9NKs3g41XDVONzmUUrEmyaifLVGCWtAmHP0usDnX9W+RN/tmbC4EUl0w6yLGvMTOwnWCFVgA5luhRg==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.12.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.12.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.12.1.tgz",
+      "integrity": "sha512-f9qiqUHm7hWSLlNW8gS9pisnsN7CRFRD58vNjptKdsqFLpkVnX00TNeD6Q0d27V9KzT7ySFyK1TZ/DShfVOv6w==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^13.5.0",
     "dayjs": "^1.11.13",
+    "framer-motion": "^12.17.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^6.30.1",

--- a/src/components/ServiceCard.jsx
+++ b/src/components/ServiceCard.jsx
@@ -1,21 +1,47 @@
 import React from 'react';
+import { StarIcon } from '@heroicons/react/20/solid';
+import { motion } from 'framer-motion';
 
-const ServiceCard = ({ service, onClick }) => (
-  <div
-    className="rounded shadow hover:shadow-lg p-4 cursor-pointer bg-white"
-    onClick={() => onClick && onClick(service)}
-  >
-    {service.avatar && (
-      <img
-        src={service.avatar}
-        alt={service.name}
-        className="w-full h-32 object-cover rounded mb-2"
-      />
-    )}
-    <h3 className="font-semibold text-lg">{service.name}</h3>
-    <p className="text-sm text-gray-500">{service.location}</p>
-    <p className="text-sm">Rating: {service.ratings}</p>
-  </div>
-);
+const ServiceCard = ({ service, onSelect }) => {
+  const rating = Math.round(service.ratings || 0);
+  return (
+    <motion.div
+      whileHover={{ y: -4 }}
+      className="group relative rounded-xl"
+    >
+      <div className="p-px rounded-xl transition-all group-hover:bg-gradient-to-r group-hover:from-primary group-hover:to-secondary">
+        <div className="bg-white rounded-[inherit] p-4 shadow">
+          {service.avatar && (
+            <img
+              src={service.avatar}
+              alt={service.name}
+              className="w-20 h-20 mx-auto mb-3 rounded-full object-cover ring-2 ring-primary"
+            />
+          )}
+          <h3 className="text-center text-lg font-semibold">{service.name}</h3>
+          <div className="mt-2 flex items-center justify-between">
+            <div className="flex">
+              {[...Array(5)].map((_, i) => (
+                <StarIcon
+                  key={i}
+                  className={`h-5 w-5 ${i < rating ? 'text-yellow-400' : 'text-gray-300'}`}
+                />
+              ))}
+            </div>
+            <span className="px-2 py-0.5 text-xs rounded bg-gray-100 text-gray-600">
+              {service.location}
+            </span>
+          </div>
+          <button
+            className="mt-4 w-full rounded bg-primary py-2 text-white hover:bg-primary/90"
+            onClick={() => onSelect?.(service)}
+          >
+            Book Now
+          </button>
+        </div>
+      </div>
+    </motion.div>
+  );
+};
 
 export default ServiceCard;

--- a/src/pages/customer/ServiceList.jsx
+++ b/src/pages/customer/ServiceList.jsx
@@ -11,7 +11,7 @@ const ServiceList = () => {
     <div>
       <div className="grid md:grid-cols-3 gap-4">
         {services.map((service) => (
-          <ServiceCard key={service.id} service={service} onClick={() => setSelected(service)} />
+          <ServiceCard key={service.id} service={service} onSelect={() => setSelected(service)} />
         ))}
       </div>
       {selected && (


### PR DESCRIPTION
## Summary
- add framer-motion for animations
- redesign `ServiceCard` with gradient hover, star ratings, location chip, and book button
- use new `onSelect` callback in `ServiceList`

## Testing
- `npm test -- -u --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6849878d76208329b23706811b5d16f9