### PR TITLE
Add framer-motion route animations

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import React, { lazy, Suspense } from 'react';
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route, useLocation } from 'react-router-dom';
+import { AnimatePresence } from 'framer-motion';
 import './App.css';
 
 const LandingPage = lazy(() => import('./pages/LandingPage'));
@@ -7,13 +8,16 @@ const CustomerLayout = lazy(() => import('./layouts/CustomerLayout'));
 const ProviderLayout = lazy(() => import('./layouts/ProviderLayout'));
 
 function App() {
+  const location = useLocation();
   return (
     <Suspense fallback={null}>
-      <Routes>
-        <Route path="/" element={<LandingPage />} />
-        <Route path="/customer/*" element={<CustomerLayout />} />
-        <Route path="/provider/*" element={<ProviderLayout />} />
-      </Routes>
+      <AnimatePresence mode="wait">
+        <Routes location={location} key={location.pathname}>
+          <Route path="/" element={<LandingPage />} />
+          <Route path="/customer/*" element={<CustomerLayout />} />
+          <Route path="/provider/*" element={<ProviderLayout />} />
+        </Routes>
+      </AnimatePresence>
     </Suspense>
   );
 }

--- a/src/layouts/CustomerLayout.jsx
+++ b/src/layouts/CustomerLayout.jsx
@@ -1,35 +1,41 @@
 import React, { lazy, Suspense } from 'react';
-import { Routes, Route, Link } from 'react-router-dom';
+import { Routes, Route, Link, useLocation } from 'react-router-dom';
+import { AnimatePresence } from 'framer-motion';
 import TopBar from '../components/TopBar';
 
 const Dashboard = lazy(() => import('../pages/customer/Dashboard'));
 const ServiceList = lazy(() => import('../pages/customer/ServiceList'));
 const Appointments = lazy(() => import('../pages/customer/Appointments'));
 
-const CustomerLayout = () => (
-  <div className="min-h-screen flex flex-col">
-    <TopBar />
-    <nav className="bg-gray-100 p-2 space-x-4">
-      <Link to="" className="hover:underline">
-        Dashboard
-      </Link>
-      <Link to="services" className="hover:underline">
-        Services
-      </Link>
-      <Link to="appointments" className="hover:underline">
-        Appointments
-      </Link>
-    </nav>
-    <div className="p-4 flex-1">
-      <Suspense fallback={null}>
-        <Routes>
-          <Route index element={<Dashboard />} />
-          <Route path="services" element={<ServiceList />} />
-          <Route path="appointments" element={<Appointments />} />
-        </Routes>
-      </Suspense>
+const CustomerLayout = () => {
+  const location = useLocation();
+  return (
+    <div className="min-h-screen flex flex-col">
+      <TopBar />
+      <nav className="bg-gray-100 p-2 space-x-4">
+        <Link to="" className="hover:underline">
+          Dashboard
+        </Link>
+        <Link to="services" className="hover:underline">
+          Services
+        </Link>
+        <Link to="appointments" className="hover:underline">
+          Appointments
+        </Link>
+      </nav>
+      <div className="p-4 flex-1">
+        <Suspense fallback={null}>
+          <AnimatePresence mode="wait">
+            <Routes location={location} key={location.pathname}>
+              <Route index element={<Dashboard />} />
+              <Route path="services" element={<ServiceList />} />
+              <Route path="appointments" element={<Appointments />} />
+            </Routes>
+          </AnimatePresence>
+        </Suspense>
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default CustomerLayout;

--- a/src/layouts/ProviderLayout.jsx
+++ b/src/layouts/ProviderLayout.jsx
@@ -1,5 +1,6 @@
 import React, { lazy, Suspense } from 'react';
-import { Routes, Route, Link } from 'react-router-dom';
+import { Routes, Route, Link, useLocation } from 'react-router-dom';
+import { AnimatePresence } from 'framer-motion';
 import TopBar from '../components/TopBar';
 
 const Overview = lazy(() => import('../pages/provider/Overview'));
@@ -7,34 +8,39 @@ const Schedule = lazy(() => import('../pages/provider/Schedule'));
 const Services = lazy(() => import('../pages/provider/Services'));
 const Products = lazy(() => import('../pages/provider/Products'));
 
-const ProviderLayout = () => (
-  <div className="min-h-screen flex flex-col">
-    <TopBar />
-    <nav className="bg-gray-100 p-2 space-x-4">
-      <Link to="" className="hover:underline">
-        Overview
-      </Link>
-      <Link to="schedule" className="hover:underline">
-        Schedule
-      </Link>
-      <Link to="services" className="hover:underline">
-        Services
-      </Link>
-      <Link to="products" className="hover:underline">
-        Products
-      </Link>
-    </nav>
-    <div className="p-4 flex-1">
-      <Suspense fallback={null}>
-        <Routes>
-          <Route index element={<Overview />} />
-          <Route path="schedule" element={<Schedule />} />
-          <Route path="services" element={<Services />} />
-          <Route path="products" element={<Products />} />
-        </Routes>
-      </Suspense>
+const ProviderLayout = () => {
+  const location = useLocation();
+  return (
+    <div className="min-h-screen flex flex-col">
+      <TopBar />
+      <nav className="bg-gray-100 p-2 space-x-4">
+        <Link to="" className="hover:underline">
+          Overview
+        </Link>
+        <Link to="schedule" className="hover:underline">
+          Schedule
+        </Link>
+        <Link to="services" className="hover:underline">
+          Services
+        </Link>
+        <Link to="products" className="hover:underline">
+          Products
+        </Link>
+      </nav>
+      <div className="p-4 flex-1">
+        <Suspense fallback={null}>
+          <AnimatePresence mode="wait">
+            <Routes location={location} key={location.pathname}>
+              <Route index element={<Overview />} />
+              <Route path="schedule" element={<Schedule />} />
+              <Route path="services" element={<Services />} />
+              <Route path="products" element={<Products />} />
+            </Routes>
+          </AnimatePresence>
+        </Suspense>
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default ProviderLayout;

--- a/src/pages/customer/Dashboard.jsx
+++ b/src/pages/customer/Dashboard.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { motion } from 'framer-motion';
 import useDummy from '../../store/useDummy';
 import ServiceCard from '../../components/ServiceCard';
 
@@ -17,7 +18,14 @@ const Dashboard = () => {
   return (
     <div>
       <div className="bg-primary text-white p-6 rounded mb-4 space-y-2">
-        <h1 className="text-2xl font-bold">Find the perfect wash</h1>
+        <motion.h1
+          className="text-2xl font-bold"
+          initial={{ x: -50, opacity: 0 }}
+          animate={{ x: 0, opacity: 1 }}
+          transition={{ duration: 0.5 }}
+        >
+          Find the perfect wash
+        </motion.h1>
         <input
           type="text"
           placeholder="Search by specialty"
@@ -26,12 +34,25 @@ const Dashboard = () => {
           onChange={(e) => setQuery(e.target.value)}
         />
       </div>
-      <div className="grid md:grid-cols-3 gap-4">
+      <motion.div
+        className="grid md:grid-cols-3 gap-4"
+        variants={{
+          hidden: {},
+          show: { transition: { staggerChildren: 0.15 } }
+        }}
+        initial="hidden"
+        animate="show"
+      >
         {top.map((service) => (
-          <ServiceCard key={service.id} service={service} />
+          <motion.div
+            key={service.id}
+            variants={{ hidden: { opacity: 0, y: 20 }, show: { opacity: 1, y: 0 } }}
+          >
+            <ServiceCard service={service} />
+          </motion.div>
         ))}
         {!top.length && <p>No services found.</p>}
-      </div>
+      </motion.div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- wrap `App` and layout routes with `AnimatePresence`
- animate `Dashboard` hero with slide in text
- add staggered fade in for service grid

## Testing
- `npm install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684988c743588329a7348a4a2a333623