### PR TITLE
Add dummy data arrays

### DIFF
--- a/src/store/dummyData.js
+++ b/src/store/dummyData.js
@@ -1,0 +1,75 @@
+export const services = [
+  {
+    id: 1,
+    name: 'Sparkle City Wash',
+    avatar: 'https://loremflickr.com/320/240/carwash?lock=1',
+    location: '123 Main St',
+    ratings: 4.7,
+    specialties: ['Exterior Wash', 'Interior Cleaning'],
+    availableSlots: [
+      { date: '2025-06-15', times: ['09:00', '11:00'] },
+      { date: '2025-06-16', times: ['10:00', '14:00'] }
+    ]
+  },
+  {
+    id: 2,
+    name: 'Shiny Wheels Auto Spa',
+    avatar: 'https://loremflickr.com/320/240/carwash?lock=2',
+    location: '456 Pine Rd',
+    ratings: 4.8,
+    specialties: ['Waxing', 'Polishing'],
+    availableSlots: [
+      { date: '2025-06-15', times: ['13:00', '15:00'] }
+    ]
+  },
+  {
+    id: 3,
+    name: 'Bubble Bath Garage',
+    avatar: 'https://loremflickr.com/320/240/carwash?lock=3',
+    location: '789 Oak Ave',
+    ratings: 4.6,
+    specialties: ['Interior Detailing'],
+    availableSlots: [
+      { date: '2025-06-17', times: ['09:30', '16:00'] }
+    ]
+  },
+  {
+    id: 4,
+    name: 'Supreme Shine Hub',
+    avatar: 'https://loremflickr.com/320/240/carwash?lock=4',
+    location: '1010 Maple Dr',
+    ratings: 4.9,
+    specialties: ['Exterior Wash', 'Paint Protection'],
+    availableSlots: [
+      { date: '2025-06-18', times: ['08:00', '12:00'] }
+    ]
+  },
+  {
+    id: 5,
+    name: 'Dazzle & Drive',
+    avatar: 'https://loremflickr.com/320/240/carwash?lock=5',
+    location: '2020 Elm St',
+    ratings: 4.5,
+    specialties: ['Full Detailing'],
+    availableSlots: [
+      { date: '2025-06-19', times: ['10:30', '14:30'] }
+    ]
+  }
+];
+
+export const products = [
+  { id: 1, name: 'Car Shampoo', code: 'CS001', qty: 10, category: 'Cleaning' },
+  { id: 2, name: 'Microfiber Cloth', code: 'MC002', qty: 25, category: 'Accessories' },
+  { id: 3, name: 'Wheel Cleaner', code: 'WC003', qty: 15, category: 'Cleaning' },
+  { id: 4, name: 'Glass Spray', code: 'GS004', qty: 30, category: 'Cleaning' },
+  { id: 5, name: 'Tire Shine', code: 'TS005', qty: 18, category: 'Accessories' },
+  { id: 6, name: 'Interior Wipes', code: 'IW006', qty: 12, category: 'Cleaning' },
+  { id: 7, name: 'Wax Polish', code: 'WP007', qty: 8, category: 'Cleaning' },
+  { id: 8, name: 'Air Freshener', code: 'AF008', qty: 20, category: 'Accessories' }
+];
+
+export const appointments = [
+  { id: 1, serviceId: 1, customerName: 'John Doe', date: '2025-06-15', time: '09:00', package: 'Basic Wash' },
+  { id: 2, serviceId: 2, customerName: 'Jane Smith', date: '2025-06-15', time: '13:00', package: 'Deluxe Wash' },
+  { id: 3, serviceId: 3, customerName: 'Mark Lee', date: '2025-06-17', time: '09:30', package: 'Detailing' }
+];

--- a/src/store/useDummy.js
+++ b/src/store/useDummy.js
@@ -1,38 +1,14 @@
 import { create } from 'zustand';
+import {
+  services as sampleServices,
+  products as sampleProducts,
+  appointments as sampleAppointments,
+} from './dummyData';
 
 const useDummy = create((set, get) => ({
-  services: [
-    {
-      id: 1,
-      name: 'Quick Clean',
-      avatar: '/avatars/service1.png',
-      location: '123 Main St',
-      ratings: 4.5,
-      specialties: ['Exterior Wash', 'Interior Cleaning'],
-      availableSlots: [
-        { date: '2025-06-15', times: ['09:00', '11:00'] },
-        { date: '2025-06-16', times: ['10:00', '14:00'] }
-      ]
-    },
-    {
-      id: 2,
-      name: 'Deluxe Detail',
-      avatar: '/avatars/service2.png',
-      location: '456 Pine Rd',
-      ratings: 4.8,
-      specialties: ['Exterior Wash', 'Waxing'],
-      availableSlots: [
-        { date: '2025-06-15', times: ['13:00', '15:00'] }
-      ]
-    }
-  ],
-  products: [
-    { id: 1, name: 'Car Shampoo', code: 'CS001', qty: 10, category: 'Cleaning' },
-    { id: 2, name: 'Microfiber Cloth', code: 'MC002', qty: 25, category: 'Accessories' }
-  ],
-  appointments: [
-    { id: 1, serviceId: 1, customerName: 'John Doe', date: '2025-06-15', time: '09:00', package: 'Basic Wash' }
-  ],
+  services: sampleServices,
+  products: sampleProducts,
+  appointments: sampleAppointments,
   packages: {
     Exterior: true,
     Interior: false,


### PR DESCRIPTION
## Summary
- add `dummyData.js` with sample services/products/appointments
- populate store initial state from dummy data

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68498a43540c8329b2467a9c3217e116