### PR TITLE
💄 Frontend Glow-Up

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,6 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet" />
     <title>React App</title>
   </head>
   <body>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,3 +1,4 @@
+// 💄 UI polish
 import React, { lazy, Suspense } from 'react';
 import { Routes, Route, useLocation } from 'react-router-dom';
 import { AnimatePresence } from 'framer-motion';

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -1,10 +1,15 @@
+// 💄 UI polish
 import React from 'react';
+import { motion } from 'framer-motion';
 
 const Card = ({ children }) => {
   return (
-    <div className="rounded-2xl shadow hover:scale-105 transform transition p-4 bg-white">
+    <motion.div
+      whileHover={{ scale: 1.05, transition: { duration: 0.2 } }}
+      className="relative rounded-2xl p-4 bg-white before:absolute before:inset-0 before:rounded-[inherit] before:p-px before:bg-gradient-to-r before:from-primary before:to-secondary before:-z-10 shadow hover:drop-shadow-glow"
+    >
       {children}
-    </div>
+    </motion.div>
   );
 };
 

--- a/src/components/ServiceCard.jsx
+++ b/src/components/ServiceCard.jsx
@@ -1,5 +1,7 @@
+// 💄 UI polish
 import React from 'react';
 import { StarIcon } from '@heroicons/react/20/solid';
+import { SparklesIcon } from '@heroicons/react/24/solid';
 import { motion } from 'framer-motion';
 
 const ServiceCard = ({ service, onSelect }) => {
@@ -20,13 +22,20 @@ const ServiceCard = ({ service, onSelect }) => {
           )}
           <h3 className="text-center text-lg font-semibold">{service.name}</h3>
           <div className="mt-2 flex items-center justify-between">
-            <div className="flex">
+            <div className="flex relative">
               {[...Array(5)].map((_, i) => (
                 <StarIcon
                   key={i}
                   className={`h-5 w-5 ${i < rating ? 'text-yellow-400' : 'text-gray-300'}`}
                 />
               ))}
+              <motion.span
+                className="absolute -top-1 -right-3 text-yellow-400"
+                animate={{ scale: [1, 1.4, 1], opacity: [1, 0, 1] }}
+                transition={{ repeat: Infinity, duration: 2 }}
+              >
+                <SparklesIcon className="w-4 h-4" />
+              </motion.span>
             </div>
             <span className="px-2 py-0.5 text-xs rounded bg-gray-100 text-gray-600">
               {service.location}

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -1,25 +1,41 @@
-import React from 'react';
+// 💄 UI polish
+import React, { useState, Fragment } from 'react';
 import { Menu, Transition } from '@headlessui/react';
-import { Fragment } from 'react';
-import { UserCircleIcon } from '@heroicons/react/24/outline';
+import { UserCircleIcon, SparklesIcon, SunIcon, MoonIcon } from '@heroicons/react/24/outline';
 
 const TopBar = () => {
+  const [dark, setDark] = useState(document.documentElement.classList.contains('dark'));
+  const toggle = () => {
+    document.documentElement.classList.toggle('dark');
+    setDark(!dark);
+  };
   return (
-    <header className="flex items-center justify-between p-4 bg-white shadow">
-      <div className="text-xl font-bold text-primary">CarWash</div>
-      <Menu as="div" className="relative inline-block text-left">
-        <Menu.Button className="flex items-center focus:outline-none">
-          <UserCircleIcon className="w-8 h-8 text-gray-600" />
-        </Menu.Button>
-        <Transition
-          as={Fragment}
-          enter="transition ease-out duration-100"
-          enterFrom="transform opacity-0 scale-95"
-          enterTo="transform opacity-100 scale-100"
-          leave="transition ease-in duration-75"
-          leaveFrom="transform opacity-100 scale-100"
-          leaveTo="transform opacity-0 scale-95"
-        >
+    <header className="flex items-center justify-between p-4 bg-white/10 backdrop-blur shadow-inner">
+      <div className="flex items-center gap-1 text-xl font-display font-bold text-primary">
+        <SparklesIcon className="w-6 h-6 text-secondary" />
+        CarWash
+      </div>
+      <div className="flex items-center gap-2">
+        <button onClick={toggle} aria-label="Toggle theme">
+          {dark ? (
+            <SunIcon className="w-6 h-6 text-yellow-400" />
+          ) : (
+            <MoonIcon className="w-6 h-6 text-gray-400" />
+          )}
+        </button>
+        <Menu as="div" className="relative inline-block text-left">
+          <Menu.Button className="flex items-center focus:outline-none">
+            <UserCircleIcon className="w-8 h-8 text-gray-600" />
+          </Menu.Button>
+          <Transition
+            as={Fragment}
+            enter="transition ease-out duration-100"
+            enterFrom="transform opacity-0 scale-95"
+            enterTo="transform opacity-100 scale-100"
+            leave="transition ease-in duration-75"
+            leaveFrom="transform opacity-100 scale-100"
+            leaveTo="transform opacity-0 scale-95"
+          >
           <Menu.Items className="absolute right-0 mt-2 w-40 origin-top-right rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none z-10">
             <div className="py-1">
               <Menu.Item>
@@ -47,7 +63,8 @@ const TopBar = () => {
             </div>
           </Menu.Items>
         </Transition>
-      </Menu>
+        </Menu>
+      </div>
     </header>
   );
 };

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,18 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* 💄 UI polish */
+body {
+  @apply bg-gradient-to-br from-slate-900 via-slate-800 to-slate-700 text-white selection:bg-secondary/60 selection:text-white;
+}
+
+@keyframes gradient {
+  0%, 100% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+}
+
+.animate-gradient {
+  background-size: 200% 200%;
+  animation: gradient 3s linear infinite;
+}

--- a/src/layouts/CustomerLayout.jsx
+++ b/src/layouts/CustomerLayout.jsx
@@ -1,36 +1,93 @@
-import React, { lazy, Suspense } from 'react';
+// 💄 UI polish
+import React, { lazy, Suspense, Fragment, useState } from 'react';
 import { Routes, Route, Link, useLocation } from 'react-router-dom';
-import { AnimatePresence } from 'framer-motion';
+import { AnimatePresence, motion } from 'framer-motion';
+import { Dialog, Transition } from '@headlessui/react';
+import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline';
 import TopBar from '../components/TopBar';
 
 const Dashboard = lazy(() => import('../pages/customer/Dashboard'));
 const ServiceList = lazy(() => import('../pages/customer/ServiceList'));
 const Appointments = lazy(() => import('../pages/customer/Appointments'));
 
+const navLinks = [
+  { to: '', label: 'Dashboard' },
+  { to: 'services', label: 'Services' },
+  { to: 'appointments', label: 'Appointments' },
+];
+
 const CustomerLayout = () => {
   const location = useLocation();
+  const [open, setOpen] = useState(false);
   return (
     <div className="min-h-screen flex flex-col">
       <TopBar />
-      <nav className="bg-gray-100 p-2 space-x-4">
-        <Link to="" className="hover:underline">
-          Dashboard
-        </Link>
-        <Link to="services" className="hover:underline">
-          Services
-        </Link>
-        <Link to="appointments" className="hover:underline">
-          Appointments
-        </Link>
-      </nav>
+      {/* navigation */}
+      <div className="relative">
+        <nav className="hidden md:flex backdrop-blur bg-white/10 shadow-inner p-2 space-x-4">
+          {navLinks.map((l) => (
+            <Link
+              key={l.to}
+              to={l.to}
+              className={`px-3 py-1 rounded hover:underline ${
+                location.pathname === (l.to ? `/customer/${l.to}` : '/customer')
+                  ? 'bg-gradient-to-r from-primary to-secondary bg-clip-text text-transparent animate-gradient'
+                  : ''
+              }`}
+            >
+              {l.label}
+            </Link>
+          ))}
+        </nav>
+        <button
+          className="md:hidden p-2"
+          onClick={() => setOpen(true)}
+          aria-label="Open menu"
+        >
+          <Bars3Icon className="w-6 h-6" />
+        </button>
+        <Transition appear show={open} as={Fragment}>
+          <Dialog as="div" className="relative z-10 md:hidden" onClose={setOpen}>
+            <div className="fixed inset-0 bg-black/50" />
+            <div className="fixed inset-0 flex items-start justify-end p-4">
+              <Dialog.Panel className="bg-white/10 backdrop-blur shadow-inner rounded w-40 p-2 space-y-2">
+                <button className="ml-auto" onClick={() => setOpen(false)}>
+                  <XMarkIcon className="w-6 h-6" />
+                </button>
+                {navLinks.map((l) => (
+                  <Link
+                    key={l.to}
+                    to={l.to}
+                    onClick={() => setOpen(false)}
+                    className={`block px-3 py-1 rounded ${
+                      location.pathname === (l.to ? `/customer/${l.to}` : '/customer')
+                        ? 'bg-gradient-to-r from-primary to-secondary bg-clip-text text-transparent animate-gradient'
+                        : 'hover:bg-white/20'
+                    }`}
+                  >
+                    {l.label}
+                  </Link>
+                ))}
+              </Dialog.Panel>
+            </div>
+          </Dialog>
+        </Transition>
+      </div>
       <div className="p-4 flex-1">
         <Suspense fallback={null}>
           <AnimatePresence mode="wait">
-            <Routes location={location} key={location.pathname}>
-              <Route index element={<Dashboard />} />
-              <Route path="services" element={<ServiceList />} />
-              <Route path="appointments" element={<Appointments />} />
-            </Routes>
+            <motion.div
+              key={location.pathname}
+              initial={{ opacity: 0, y: 10 }}
+              animate={{ opacity: 1, y: 0, transition: { duration: 0.4 } }}
+              exit={{ opacity: 0, y: -10, transition: { duration: 0.4 } }}
+            >
+              <Routes location={location}>
+                <Route index element={<Dashboard />} />
+                <Route path="services" element={<ServiceList />} />
+                <Route path="appointments" element={<Appointments />} />
+              </Routes>
+            </motion.div>
           </AnimatePresence>
         </Suspense>
       </div>

--- a/src/layouts/ProviderLayout.jsx
+++ b/src/layouts/ProviderLayout.jsx
@@ -1,6 +1,9 @@
-import React, { lazy, Suspense } from 'react';
+// 💄 UI polish
+import React, { lazy, Suspense, Fragment, useState } from 'react';
 import { Routes, Route, Link, useLocation } from 'react-router-dom';
-import { AnimatePresence } from 'framer-motion';
+import { AnimatePresence, motion } from 'framer-motion';
+import { Dialog, Transition } from '@headlessui/react';
+import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline';
 import TopBar from '../components/TopBar';
 
 const Overview = lazy(() => import('../pages/provider/Overview'));
@@ -8,34 +11,81 @@ const Schedule = lazy(() => import('../pages/provider/Schedule'));
 const Services = lazy(() => import('../pages/provider/Services'));
 const Products = lazy(() => import('../pages/provider/Products'));
 
+const navLinks = [
+  { to: '', label: 'Overview' },
+  { to: 'schedule', label: 'Schedule' },
+  { to: 'services', label: 'Services' },
+  { to: 'products', label: 'Products' },
+];
+
 const ProviderLayout = () => {
   const location = useLocation();
+  const [open, setOpen] = useState(false);
   return (
     <div className="min-h-screen flex flex-col">
       <TopBar />
-      <nav className="bg-gray-100 p-2 space-x-4">
-        <Link to="" className="hover:underline">
-          Overview
-        </Link>
-        <Link to="schedule" className="hover:underline">
-          Schedule
-        </Link>
-        <Link to="services" className="hover:underline">
-          Services
-        </Link>
-        <Link to="products" className="hover:underline">
-          Products
-        </Link>
-      </nav>
+      <div className="relative">
+        <nav className="hidden md:flex backdrop-blur bg-white/10 shadow-inner p-2 space-x-4">
+          {navLinks.map((l) => (
+            <Link
+              key={l.to}
+              to={l.to}
+              className={`px-3 py-1 rounded hover:underline ${
+                location.pathname === (l.to ? `/provider/${l.to}` : '/provider')
+                  ? 'bg-gradient-to-r from-primary to-secondary bg-clip-text text-transparent animate-gradient'
+                  : ''
+              }`}
+            >
+              {l.label}
+            </Link>
+          ))}
+        </nav>
+        <button className="md:hidden p-2" onClick={() => setOpen(true)} aria-label="Open menu">
+          <Bars3Icon className="w-6 h-6" />
+        </button>
+        <Transition appear show={open} as={Fragment}>
+          <Dialog as="div" className="relative z-10 md:hidden" onClose={setOpen}>
+            <div className="fixed inset-0 bg-black/50" />
+            <div className="fixed inset-0 flex items-start justify-end p-4">
+              <Dialog.Panel className="bg-white/10 backdrop-blur shadow-inner rounded w-40 p-2 space-y-2">
+                <button className="ml-auto" onClick={() => setOpen(false)}>
+                  <XMarkIcon className="w-6 h-6" />
+                </button>
+                {navLinks.map((l) => (
+                  <Link
+                    key={l.to}
+                    to={l.to}
+                    onClick={() => setOpen(false)}
+                    className={`block px-3 py-1 rounded ${
+                      location.pathname === (l.to ? `/provider/${l.to}` : '/provider')
+                        ? 'bg-gradient-to-r from-primary to-secondary bg-clip-text text-transparent animate-gradient'
+                        : 'hover:bg-white/20'
+                    }`}
+                  >
+                    {l.label}
+                  </Link>
+                ))}
+              </Dialog.Panel>
+            </div>
+          </Dialog>
+        </Transition>
+      </div>
       <div className="p-4 flex-1">
         <Suspense fallback={null}>
           <AnimatePresence mode="wait">
-            <Routes location={location} key={location.pathname}>
-              <Route index element={<Overview />} />
-              <Route path="schedule" element={<Schedule />} />
-              <Route path="services" element={<Services />} />
-              <Route path="products" element={<Products />} />
-            </Routes>
+            <motion.div
+              key={location.pathname}
+              initial={{ opacity: 0, y: 10 }}
+              animate={{ opacity: 1, y: 0, transition: { duration: 0.4 } }}
+              exit={{ opacity: 0, y: -10, transition: { duration: 0.4 } }}
+            >
+              <Routes location={location}>
+                <Route index element={<Overview />} />
+                <Route path="schedule" element={<Schedule />} />
+                <Route path="services" element={<Services />} />
+                <Route path="products" element={<Products />} />
+              </Routes>
+            </motion.div>
           </AnimatePresence>
         </Suspense>
       </div>

--- a/src/pages/customer/Dashboard.jsx
+++ b/src/pages/customer/Dashboard.jsx
@@ -1,5 +1,7 @@
+// 💄 UI polish
 import React, { useState } from 'react';
 import { motion } from 'framer-motion';
+import { Combobox } from '@headlessui/react';
 import useDummy from '../../store/useDummy';
 import ServiceCard from '../../components/ServiceCard';
 
@@ -17,25 +19,25 @@ const Dashboard = () => {
 
   return (
     <div>
-      <div className="bg-primary text-white p-6 rounded mb-4 space-y-2">
+      <div className="bg-white/10 backdrop-blur p-6 rounded mb-4 space-y-2 animate-pulse">
         <motion.h1
-          className="text-2xl font-bold"
+          className="text-3xl font-bold bg-gradient-to-r from-primary to-secondary bg-clip-text text-transparent"
           initial={{ x: -50, opacity: 0 }}
           animate={{ x: 0, opacity: 1 }}
           transition={{ duration: 0.5 }}
         >
           Find the perfect wash
         </motion.h1>
-        <input
-          type="text"
-          placeholder="Search by specialty"
-          className="w-full p-2 rounded text-black"
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-        />
+        <Combobox value={query} onChange={setQuery}>
+          <Combobox.Input
+            className="w-full p-2 rounded text-black"
+            placeholder="Search by specialty"
+            onChange={(e) => setQuery(e.target.value)}
+          />
+        </Combobox>
       </div>
       <motion.div
-        className="grid md:grid-cols-3 gap-4"
+        className="grid md:grid-cols-2 lg:grid-cols-3 gap-4"
         variants={{
           hidden: {},
           show: { transition: { staggerChildren: 0.15 } }

--- a/src/pages/customer/ServiceList.jsx
+++ b/src/pages/customer/ServiceList.jsx
@@ -1,3 +1,4 @@
+// 💄 UI polish
 import React, { useState } from 'react';
 import useDummy from '../../store/useDummy';
 import ServiceCard from '../../components/ServiceCard';
@@ -9,7 +10,7 @@ const ServiceList = () => {
 
   return (
     <div>
-      <div className="grid md:grid-cols-3 gap-4">
+      <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
         {services.map((service) => (
           <ServiceCard key={service.id} service={service} onSelect={() => setSelected(service)} />
         ))}

--- a/src/pages/provider/Overview.jsx
+++ b/src/pages/provider/Overview.jsx
@@ -1,5 +1,7 @@
+// 💄 UI polish
 import React from 'react';
 import dayjs from 'dayjs';
+import { motion } from 'framer-motion';
 import useDummy from '../../store/useDummy';
 import Card from '../../components/Card';
 
@@ -13,20 +15,25 @@ const Overview = () => {
   const lowStock = products.filter((p) => p.qty < 5).length;
 
   return (
-    <div className="grid md:grid-cols-3 gap-4">
-      <Card>
-        <h3 className="text-lg font-semibold">Total Bookings</h3>
-        <p className="text-2xl">{total}</p>
-      </Card>
-      <Card>
-        <h3 className="text-lg font-semibold">Today's Bookings</h3>
-        <p className="text-2xl">{todayCount}</p>
-      </Card>
-      <Card>
-        <h3 className="text-lg font-semibold">Low Stock Products</h3>
-        <p className="text-2xl">{lowStock}</p>
-      </Card>
-    </div>
+    <motion.div
+      className="grid md:grid-cols-2 lg:grid-cols-3 gap-4"
+      initial="hidden"
+      animate="show"
+      variants={{ hidden: {}, show: { transition: { staggerChildren: 0.1 } } }}
+    >
+      {[{ label: 'Total Bookings', value: total }, { label: "Today's Bookings", value: todayCount }, { label: 'Low Stock Products', value: lowStock }].map((item) => (
+        <motion.div
+          key={item.label}
+          variants={{ hidden: { opacity: 0, y: 20 }, show: { opacity: 1, y: 0 } }}
+          className="drop-shadow-glow"
+        >
+          <Card>
+            <h3 className="text-lg font-semibold">{item.label}</h3>
+            <p className="text-2xl">{item.value}</p>
+          </Card>
+        </motion.div>
+      ))}
+    </motion.div>
   );
 };
 

--- a/src/pages/provider/Products.jsx
+++ b/src/pages/provider/Products.jsx
@@ -1,3 +1,4 @@
+// 💄 UI polish
 import React, { useState } from 'react';
 import useDummy from '../../store/useDummy';
 import Card from '../../components/Card';
@@ -97,7 +98,7 @@ const Products = () => {
       <button className="px-3 py-1 rounded bg-primary text-white" onClick={() => setAdding(true)}>
         Add Product
       </button>
-      <div className="grid md:grid-cols-3 gap-4">
+      <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
         {products.map((p) => (
           <ProductCard key={p.id} product={p} />
         ))}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,11 +1,19 @@
 /** @type {import('tailwindcss').Config} */
+// 💄 UI polish
 module.exports = {
+  darkMode: 'class',
   content: ['./src/**/*.{js,jsx,ts,tsx}'],
   theme: {
     extend: {
       colors: {
         primary: '#2563eb',
         secondary: '#f97316',
+      },
+      fontFamily: {
+        display: ['Poppins', 'sans-serif'],
+      },
+      dropShadow: {
+        glow: '0 0 15px #2563eb66',
       },
     },
   },


### PR DESCRIPTION
## Summary
- add glassmorphism gradient background and gradient text util
- extend Tailwind theme with Poppins font and glow dropShadow
- revamp TopBar with sparkles logo and dark mode toggle
- modernize navigation and animations in Customer and Provider layouts
- beautify cards and service listings with framer-motion effects

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68498c8df3b8832981f864e25007a61d